### PR TITLE
DRAFT a11y fixes

### DIFF
--- a/404.html
+++ b/404.html
@@ -17,7 +17,7 @@
     <a class="sr-only sr-only-focusable skip-link" href="#main">Skip to main content</a>
     <div class="green-banner-wrapper">
       <div class="green-banner">
-        <p>This version of the website was created in 2025. See the <a href="#">Site Information Page</a> for contact information, data downloads, and other details.</p>
+        <p>This version of the website was created in 2025. See the <a href="info.html">Site Information Page</a> for contact information, data downloads, and other details.</p>
       </div>
     </div>
   <div class="header">

--- a/404.html
+++ b/404.html
@@ -13,8 +13,17 @@
 </head>
 
 <body>
-  <header class="header"><a class="sr-only sr-only-focusable skip-link" href="#main">Skip to main content</a><span
-      class="sr-only">Army Officers' Wives on the Great Plains, 1865-1900</span></header>
+  <header>
+    <a class="sr-only sr-only-focusable skip-link" href="#main">Skip to main content</a>
+    <div class="green-banner-wrapper">
+      <div class="green-banner">
+        <p>This is a simplified version of the website with no active updates. See the <a href="#">Site Information Page</a> for contact information, data downloads, and other details. </p>
+      </div>
+    </div>
+  <div class="header">
+    <span
+      class="sr-only">Army Officers' Wives on the Great Plains, 1865-1900</span></div>
+  </header>
   <main id="page_margins">
     <div id="main">
       <div id="col1">

--- a/404.html
+++ b/404.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html
+  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+
+<head>
+  <title>"I could, I can and I do!: Daily Life in a Great Plains Military Post</title>
+  <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+  <link href="http://plainshumanities.unl.edu/army_officers_wives/css/reset.css" rel="stylesheet" type="text/css" />
+  <link href="http://plainshumanities.unl.edu/army_officers_wives/css/layout.css" rel="stylesheet" type="text/css" />
+  <link href="http://plainshumanities.unl.edu/army_officers_wives/css/aow.css" rel="stylesheet" type="text/css" /><!--[if IE 6]>
+  <link href="http://plainshumanities.unl.edu/army_officers_wives/css/ie.css" rel="stylesheet" type="text/css" />
+  <![endif]-->
+</head>
+
+<body>
+  <header class="header"><a class="sr-only sr-only-focusable skip-link" href="#main">Skip to main content</a><span
+      class="sr-only">Army Officers' Wives on the Great Plains, 1865-1900</span></header>
+  <main id="page_margins">
+    <div id="main">
+      <div id="col1">
+        <div class="list">
+          <ul xmlns="" class="mainmenu">
+            <li>
+              <h3><a href="http://plainshumanities.unl.edu/army_officers_wives/">Home</a></h3>
+            </li>
+            <li class="selected">
+              <h3><a href="http://plainshumanities.unl.edu/army_officers_wives/daily_life/">Daily Life</a></h3>
+              <ul>
+                <li class="current"><a
+                    href="http://plainshumanities.unl.edu/army_officers_wives/daily_life/">Introduction</a></li>
+                <li><a href="http://plainshumanities.unl.edu/army_officers_wives/daily_life/p0002">Daily life in a Great
+                    Plains Military Post</a></li>
+                <li><a href="http://plainshumanities.unl.edu/army_officers_wives/daily_life/p0003">Climate and
+                    Environment</a></li>
+                <li><a href="http://plainshumanities.unl.edu/army_officers_wives/daily_life/p0004">Procuring Food and
+                    Clothing</a></li>
+                <li><a href="http://plainshumanities.unl.edu/army_officers_wives/daily_life/p0005">Church and School</a>
+                </li>
+                <li><a href="http://plainshumanities.unl.edu/army_officers_wives/daily_life/p0006">Conclusion</a></li>
+              </ul>
+            </li>
+            <li class="hidden">
+              <h3><a href="http://plainshumanities.unl.edu/army_officers_wives/family_life/">Family Life</a></h3>
+            </li>
+            <li class="hidden">
+              <h3><a href="http://plainshumanities.unl.edu/army_officers_wives/rank_and_class/">Rank and Class</a></h3>
+            </li>
+            <li class="hidden">
+              <h3><a href="http://plainshumanities.unl.edu/army_officers_wives/indians/">Indians</a></h3>
+            </li>
+          </ul>
+        </div>
+        <div class="listlow">
+          <ul class="lowermenu">
+            <li><span class="h1">Context</span></li>
+            <li><a href="http://plainshumanities.unl.edu/army_officers_wives/biographies">The Women</a></li>
+            <li><a href="http://plainshumanities.unl.edu/army_officers_wives/military_posts">Military Posts</a></li>
+            <li><span class="h1">About the Project</span></li>
+            <li><a href="http://plainshumanities.unl.edu/army_officers_wives/bibliography">Bibliography</a></li>
+            <li><a href="http://plainshumanities.unl.edu/army_officers_wives/lesson_plans">Lesson Plans</a></li>
+          </ul>
+        </div>
+      </div>
+      <div id="col3">
+        <div id="col3_content" class="clearfix">
+          <div class="content">
+
+            <h1>404 - Page not found</h1>
+            <p>
+              The requested page could not be found. The site framework has been updated as the site has moved out of an active update stage. Some links and URL structures may have changed. Please see the CDRH project stages page [TODO: link] for details.
+            </p>
+
+
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+  <footer class="footer">
+    <p><a href="http://plainshumanities.unl.edu/army_officers_wives/about/methodology">Methodology</a> |
+      <a href="http://plainshumanities.unl.edu/army_officers_wives/about/acknowledgements">Acknowledgements</a> |
+      <a href="http://plainshumanities.unl.edu/army_officers_wives/about/barbara_handy-marchello">About the Author</a>
+    </p>
+    <p><a href="http://www.unl.edu">University of Nebraska-Lincoln</a>, <a href="http://cdrh.unl.edu">Center for Digital
+        Research in the Humanities</a></p><img
+      src="http://plainshumanities.unl.edu/army_officers_wives/web-images/unl_logo.gif" class="right" alt=""
+      role="presentation" />
+  </footer>
+</body>
+
+</html>

--- a/404.html
+++ b/404.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 
 <head>
-  <title>"I could, I can and I do!: Daily Life in a Great Plains Military Post</title>
+  <title>404 - Page not found</title>
   <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
   <link href="http://plainshumanities.unl.edu/army_officers_wives/css/reset.css" rel="stylesheet" type="text/css" />
   <link href="http://plainshumanities.unl.edu/army_officers_wives/css/layout.css" rel="stylesheet" type="text/css" />

--- a/404.html
+++ b/404.html
@@ -17,7 +17,7 @@
     <a class="sr-only sr-only-focusable skip-link" href="#main">Skip to main content</a>
     <div class="green-banner-wrapper">
       <div class="green-banner">
-        <p>This is a simplified version of the website with no active updates. See the <a href="#">Site Information Page</a> for contact information, data downloads, and other details. </p>
+        <p>This version of the website was created in 2025. See the <a href="#">Site Information Page</a> for contact information, data downloads, and other details.</p>
       </div>
     </div>
   <div class="header">

--- a/css/aow-front.css
+++ b/css/aow-front.css
@@ -1,45 +1,45 @@
 /* CSS Document */
 /* army wives 1st page */
 
-div.header {height:89px; background:url(../web-images/headeralt.jpg) top left no-repeat }
-div.blue {background:url(../web-images/darkblue.jpg) repeat }
-div.header h1 {display:none}
-div.header h3 {display:none}
+.header {height:89px; background:url(../web-images/headeralt.jpg) top left no-repeat }
+.blue {background:url(../web-images/darkblue.jpg) repeat }
+.header h1 {display:none}
+.header h3 {display:none}
 body { color:#000000; font-family:"Times New Roman", Times, serif;  background:url(../web-images/blue.jpg) repeat; background-color:#88C2E6 } 
 
-div.lists {height:2800px}
+.lists {height:2800px}
 
-div.list2 {font:Arial, Helvetica, sans-serif; font-size:12px}
-div.photo { width:645px; height:400px; background:url(../web-images/photo.jpg) top left no-repeat}
-div.photo h1 { display:none}
-div.title {width:645px; height:33px; background:url(../web-images/title.jpg) left no-repeat}
-div.title h1 {font-family:Arial, Helvetica, sans-serif; font-style:italic; font-weight:bold; font-size:20px; padding-left:15px; padding-top:5px}
-div.content p {font-size:14px; padding:10px 10px 15px 15px; line-height:1.5em}
-div.lists {background:url(../web-images/darkblue.jpg) repeat}
-div.list1 a:link {color:#492B01}
-div.list1 a:visited {color:#492B01}
-div.list1 a:hover {color:#FFFFFF}
-div.list1 {background:url(../web-images/lines.jpg)}
-div.list1 li{height:23.5px; margin-bottom:23px}
-div.list1 {padding-top:25px; padding-left:25px; font-size:17px; font-weight:bold; padding-bottom:15px}
-div.list2  li{height:25px; margin-left:10px; font-family:Arial, Helvetica, sans-serif; font-weight:bold}
-div.list2 a:link {color:#000000; text-decoration:none}
-div.list2 a:visited {color:#3e2f18; text-decoration:none}
-div.list2 a:hover {color:#FFFFFF; text-decoration:underline}
-div.list2 {padding-left:25px}
-/*div.ne {margin-top:-70; float:right}*/
-
-
+.list2 {font:Arial, Helvetica, sans-serif; font-size:12px}
+.photo { width:645px; height:400px; background:url(../web-images/photo.jpg) top left no-repeat}
+.photo h1 { display:none}
+.title {width:645px; height:33px; background:url(../web-images/title.jpg) left no-repeat}
+.title h1 {font-family:Arial, Helvetica, sans-serif; font-style:italic; font-weight:bold; font-size:20px; padding-left:15px; padding-top:5px}
+.content p {font-size:14px; padding:10px 10px 15px 15px; line-height:1.5em}
+.lists {background:url(../web-images/darkblue.jpg) repeat}
+.list1 a:link {color:#492B01}
+.list1 a:visited {color:#492B01}
+.list1 a:hover {color:#FFFFFF}
+.list1 {background:url(../web-images/lines.jpg)}
+.list1 li{height:23.5px; margin-bottom:23px}
+.list1 {padding-top:25px; padding-left:25px; font-size:17px; font-weight:bold; padding-bottom:15px}
+.list2  li{height:25px; margin-left:10px; font-family:Arial, Helvetica, sans-serif; font-weight:bold}
+.list2 a:link {color:#000000; text-decoration:none}
+.list2 a:visited {color:#3e2f18; text-decoration:none}
+.list2 a:hover {color:#FFFFFF; text-decoration:underline}
+.list2 {padding-left:25px}
+/*.ne {margin-top:-70; float:right}*/
 
 
-div.footer {background-color:#D3AC92; font-size:14px; clear:both; text-align:right; padding-right:20px; height: 110px;}
-div.footer a {text-decoration:none}
-div.footer a:link {color:#000000}
-div.footer a:visited {color:#000000}
-div.footer a:hover {color:#FFFFFF}
+
+
+.footer {background-color:#D3AC92; font-size:14px; clear:both; text-align:right; padding-right:20px; height: 110px;}
+.footer a {text-decoration:none}
+.footer a:link {color:#000000}
+.footer a:visited {color:#000000}
+.footer a:hover {color:#FFFFFF}
 
 p.bold {font-family:Arial, Helvetica, sans-serif; font-weight:bold; margin:10px 0px 10px 0px; font-size:13px}
-div.content a:link {color:#10669b}
-div.content a:visited {color:#00568b}
-div.content a:hover {color:#d2e8f6}
+.content a:link {color:#10669b}
+.content a:visited {color:#00568b}
+.content a:hover {color:#d2e8f6}
 .right {float: right}

--- a/css/aow-front.css
+++ b/css/aow-front.css
@@ -3,8 +3,6 @@
 
 .header {height:89px; background:url(../web-images/headeralt.jpg) top left no-repeat }
 .blue {background:url(../web-images/darkblue.jpg) repeat }
-.header h1 {display:none}
-.header h3 {display:none}
 body { color:#000000; font-family:"Times New Roman", Times, serif;  background:url(../web-images/blue.jpg) repeat; background-color:#88C2E6 } 
 
 .lists {height:2800px}

--- a/css/aow-front.css
+++ b/css/aow-front.css
@@ -18,14 +18,14 @@ body { color:#000000; font-family:"Times New Roman", Times, serif;  background:u
 .lists {background:url(../web-images/darkblue.jpg) repeat}
 .list1 a:link {color:#492B01}
 .list1 a:visited {color:#492B01}
-.list1 a:hover {color:#1D1202; text-decoration: underline; text-decoration-thickness: 2px; text-decoration-color: #492B01;}
+.list1 a:hover {color:#1D1202; text-decoration: underline 2px #1D1202;}
 .list1 {background:url(../web-images/lines.jpg)}
 .list1 li{height:23.5px; margin-bottom:23px}
 .list1 {padding-top:25px; padding-left:25px; font-size:17px; font-weight:bold; padding-bottom:15px}
 .list2  li{height:25px; margin-left:10px; font-family:Arial, Helvetica, sans-serif; font-weight:bold}
 .list2 a:link {color:#000000; text-decoration:none}
 .list2 a:visited {color:#3e2f18; text-decoration:none}
-.list2 a:hover {color:#1D1202; text-decoration:underline; text-decoration-thickness: 2px;}
+.list2 a:hover {color:#1D1202; text-decoration: underline 2px #1D1202;}
 .list2 {padding-left:25px}
 /*.ne {margin-top:-70; float:right}*/
 
@@ -36,12 +36,12 @@ body { color:#000000; font-family:"Times New Roman", Times, serif;  background:u
 .footer a {text-decoration:none}
 .footer a:link {color:#000000}
 .footer a:visited {color:#000000}
-.footer a:hover {color:#1D1202; text-decoration: underline; text-decoration-thickness: 2px; }
+.footer a:hover {color:#1D1202; text-decoration: underline 2px #1D1202;}
 
 p.bold {font-family:Arial, Helvetica, sans-serif; font-weight:bold; margin:10px 0px 10px 0px; font-size:13px}
 .content a:link {color:#10669b}
 .content a:visited {color:#00568b}
-.content a:hover {color:#d2e8f6}
+.content a:hover {color:#003454; text-decoration: underline #003454 2px;}
 .right {float: right}
 
 

--- a/css/aow-front.css
+++ b/css/aow-front.css
@@ -76,3 +76,34 @@ a.sr-only-focusable:hover, a.sr-only-focusable:focus {
 a.sr-only.skip-link {
   background-color: white;
 }
+
+
+.green-banner-wrapper {
+    max-width: 100%;
+}
+
+.green-banner {
+  background-color: #bbdfbb;
+  border-bottom: 2px solid #466f46;
+  padding: 15px 20px;
+}
+
+.green-banner p {
+  margin: 0;
+}
+
+.green-banner p a,
+.green-banner p a:visited {
+  color: #0000EE;
+  background: none;
+  margin: 0;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.green-banner p a:hover {
+  background: none;
+  color: #010194;
+  margin: 0;
+  padding: 0;
+}

--- a/css/aow-front.css
+++ b/css/aow-front.css
@@ -77,23 +77,22 @@ a.sr-only.skip-link {
   background-color: white;
 }
 
-
-.green-banner-wrapper {
+.static-banner-wrapper {
     max-width: 100%;
 }
 
-.green-banner {
+.static-banner {
   background-color: #bbdfbb;
-  border-bottom: 2px solid #466f46;
+  border-bottom: 1px solid #466f46;
   padding: 15px 20px;
 }
 
-.green-banner p {
+.static-banner p {
   margin: 0;
 }
 
-.green-banner p a,
-.green-banner p a:visited {
+.static-banner p a,
+.static-banner p a:visited {
   color: #0000EE;
   background: none;
   margin: 0;
@@ -101,7 +100,7 @@ a.sr-only.skip-link {
   text-decoration: underline;
 }
 
-.green-banner p a:hover {
+.static-banner p a:hover {
   background: none;
   color: #010194;
   margin: 0;

--- a/css/aow-front.css
+++ b/css/aow-front.css
@@ -11,21 +11,21 @@ body { color:#000000; font-family:"Times New Roman", Times, serif;  background:u
 
 .list2 {font:Arial, Helvetica, sans-serif; font-size:12px}
 .photo { width:645px; height:400px; background:url(../web-images/photo.jpg) top left no-repeat}
-.photo h1 { display:none}
 .title {width:645px; height:33px; background:url(../web-images/title.jpg) left no-repeat}
-.title h1 {font-family:Arial, Helvetica, sans-serif; font-style:italic; font-weight:bold; font-size:20px; padding-left:15px; padding-top:5px}
+.title h1, .title h2 {font-family:Arial, Helvetica, sans-serif; font-style:italic; font-weight:bold; font-size:20px; padding-left:15px; padding-top:5px}
+.content {background-color: #cfe8ff;}
 .content p {font-size:14px; padding:10px 10px 15px 15px; line-height:1.5em}
 .lists {background:url(../web-images/darkblue.jpg) repeat}
 .list1 a:link {color:#492B01}
 .list1 a:visited {color:#492B01}
-.list1 a:hover {color:#FFFFFF}
+.list1 a:hover {color:#1D1202; text-decoration: underline; text-decoration-thickness: 2px; text-decoration-color: #492B01;}
 .list1 {background:url(../web-images/lines.jpg)}
 .list1 li{height:23.5px; margin-bottom:23px}
 .list1 {padding-top:25px; padding-left:25px; font-size:17px; font-weight:bold; padding-bottom:15px}
 .list2  li{height:25px; margin-left:10px; font-family:Arial, Helvetica, sans-serif; font-weight:bold}
 .list2 a:link {color:#000000; text-decoration:none}
 .list2 a:visited {color:#3e2f18; text-decoration:none}
-.list2 a:hover {color:#FFFFFF; text-decoration:underline}
+.list2 a:hover {color:#1D1202; text-decoration:underline; text-decoration-thickness: 2px;}
 .list2 {padding-left:25px}
 /*.ne {margin-top:-70; float:right}*/
 
@@ -36,10 +36,45 @@ body { color:#000000; font-family:"Times New Roman", Times, serif;  background:u
 .footer a {text-decoration:none}
 .footer a:link {color:#000000}
 .footer a:visited {color:#000000}
-.footer a:hover {color:#FFFFFF}
+.footer a:hover {color:#1D1202; text-decoration: underline; text-decoration-thickness: 2px; }
 
 p.bold {font-family:Arial, Helvetica, sans-serif; font-weight:bold; margin:10px 0px 10px 0px; font-size:13px}
 .content a:link {color:#10669b}
 .content a:visited {color:#00568b}
 .content a:hover {color:#d2e8f6}
 .right {float: right}
+
+
+/* /////////////////
+Accessibility Fixes
+///////////////// */
+
+/* Skip to main content link */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.sr-only-focusable:active, .sr-only-focusable:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+}
+
+a.sr-only-focusable:hover, a.sr-only-focusable:focus {
+  color: #345c87;
+  text-decoration: underline;
+}
+
+a.sr-only.skip-link {
+  background-color: white;
+}

--- a/css/aow-front2.css
+++ b/css/aow-front2.css
@@ -3,8 +3,6 @@
 
 .header {height:89px; background:url(../web-images/headeralt.jpg) top left no-repeat }
 .blue {background:url(../web-images/darkblue.jpg) repeat }
-.header h1 {display:none}
-.header h3 {display:none}
 body { color:#000000; font-family:"Times New Roman", Times, serif;  background:url(../web-images/blue.jpg) repeat; background-color:#88C2E6 } 
 
 .lists {height:2800px}
@@ -15,6 +13,7 @@ body { color:#000000; font-family:"Times New Roman", Times, serif;  background:u
 .title {width:645px; height:33px; background:url(../web-images/title.jpg) left no-repeat}
 .title h1 {font-family:Arial, Helvetica, sans-serif; font-style:italic; font-weight:bold; font-size:20px; padding-left:15px; padding-top:5px}
 .content {background-color: #cfe8ff;}
+
 .content p {font-size:14px; padding:10px 10px 15px 15px; line-height:1.5em}
 .lists {background:url(../web-images/darkblue.jpg) repeat}
 .list1 a:link {color:#492B01}

--- a/css/aow-front2.css
+++ b/css/aow-front2.css
@@ -14,18 +14,19 @@ body { color:#000000; font-family:"Times New Roman", Times, serif;  background:u
 .photo h1 { display:none}
 .title {width:645px; height:33px; background:url(../web-images/title.jpg) left no-repeat}
 .title h1 {font-family:Arial, Helvetica, sans-serif; font-style:italic; font-weight:bold; font-size:20px; padding-left:15px; padding-top:5px}
+.content {background-color: #cfe8ff;}
 .content p {font-size:14px; padding:10px 10px 15px 15px; line-height:1.5em}
 .lists {background:url(../web-images/darkblue.jpg) repeat}
 .list1 a:link {color:#492B01}
 .list1 a:visited {color:#492B01}
-.list1 a:hover {color:#FFFFFF}
+.list1 a:hover {color:#1D1202; text-decoration: underline 2px #1D1202;}
 .list1 {background:url(../web-images/lines.jpg)}
 .list1 li{height:23.5px; margin-bottom:23px}
 .list1 {padding-top:25px; padding-left:25px; font-size:17px; font-weight:bold; padding-bottom:15px}
 .list2  li{height:25px; margin-left:10px; font-family:Arial, Helvetica, sans-serif; font-weight:bold}
 .list2 a:link {color:#000000; text-decoration:none}
 .list2 a:visited {color:#3e2f18; text-decoration:none}
-.list2 a:hover {color:#FFFFFF; text-decoration:underline}
+.list2 a:hover {color:#1D1202; text-decoration: underline 2px #1D1202;}
 .list2 {padding-left:25px}
 /*.ne {margin-top:-70; float:right}*/
 
@@ -37,9 +38,9 @@ body { color:#000000; font-family:"Times New Roman", Times, serif;  background:u
 .footer a {text-decoration:none}
 .footer a:link {color:#000000}
 .footer a:visited {color:#000000}
-.footer a:hover {color:#FFFFFF}
+.footer a:hover {color:#1D1202; text-decoration: underline 2px #1D1202;}
 
 p.bold {font-family:Arial, Helvetica, sans-serif; font-weight:bold; margin:10px 0px 10px 0px; font-size:13px}
 .content a:link {color:#10669b}
 .content a:visited {color:#00568b}
-.content a:hover {color:#d2e8f6}
+.content a:hover {color:#003454; text-decoration: underline #003454 2px;}

--- a/css/aow-front2.css
+++ b/css/aow-front2.css
@@ -1,45 +1,45 @@
 /* CSS Document */
 /* army wives 1st page */
 
-div.header {height:89px; background:url(../web-images/headeralt.jpg) top left no-repeat }
-div.blue {background:url(../web-images/darkblue.jpg) repeat }
-div.header h1 {display:none}
-div.header h3 {display:none}
+.header {height:89px; background:url(../web-images/headeralt.jpg) top left no-repeat }
+.blue {background:url(../web-images/darkblue.jpg) repeat }
+.header h1 {display:none}
+.header h3 {display:none}
 body { color:#000000; font-family:"Times New Roman", Times, serif;  background:url(../web-images/blue.jpg) repeat; background-color:#88C2E6 } 
 
-div.lists {height:2800px}
+.lists {height:2800px}
 
-div.list2 {font:Arial, Helvetica, sans-serif; font-size:12px}
-div.photo { width:645px; height:400px; background:url(../web-images/photo.jpg) top left no-repeat}
-div.photo h1 { display:none}
-div.title {width:645px; height:33px; background:url(../web-images/title.jpg) left no-repeat}
-div.title h1 {font-family:Arial, Helvetica, sans-serif; font-style:italic; font-weight:bold; font-size:20px; padding-left:15px; padding-top:5px}
-div.content p {font-size:14px; padding:10px 10px 15px 15px; line-height:1.5em}
-div.lists {background:url(../web-images/darkblue.jpg) repeat}
-div.list1 a:link {color:#492B01}
-div.list1 a:visited {color:#492B01}
-div.list1 a:hover {color:#FFFFFF}
-div.list1 {background:url(../web-images/lines.jpg)}
-div.list1 li{height:23.5px; margin-bottom:23px}
-div.list1 {padding-top:25px; padding-left:25px; font-size:17px; font-weight:bold; padding-bottom:15px}
-div.list2  li{height:25px; margin-left:10px; font-family:Arial, Helvetica, sans-serif; font-weight:bold}
-div.list2 a:link {color:#000000; text-decoration:none}
-div.list2 a:visited {color:#3e2f18; text-decoration:none}
-div.list2 a:hover {color:#FFFFFF; text-decoration:underline}
-div.list2 {padding-left:25px}
-/*div.ne {margin-top:-70; float:right}*/
-
-
+.list2 {font:Arial, Helvetica, sans-serif; font-size:12px}
+.photo { width:645px; height:400px; background:url(../web-images/photo.jpg) top left no-repeat}
+.photo h1 { display:none}
+.title {width:645px; height:33px; background:url(../web-images/title.jpg) left no-repeat}
+.title h1 {font-family:Arial, Helvetica, sans-serif; font-style:italic; font-weight:bold; font-size:20px; padding-left:15px; padding-top:5px}
+.content p {font-size:14px; padding:10px 10px 15px 15px; line-height:1.5em}
+.lists {background:url(../web-images/darkblue.jpg) repeat}
+.list1 a:link {color:#492B01}
+.list1 a:visited {color:#492B01}
+.list1 a:hover {color:#FFFFFF}
+.list1 {background:url(../web-images/lines.jpg)}
+.list1 li{height:23.5px; margin-bottom:23px}
+.list1 {padding-top:25px; padding-left:25px; font-size:17px; font-weight:bold; padding-bottom:15px}
+.list2  li{height:25px; margin-left:10px; font-family:Arial, Helvetica, sans-serif; font-weight:bold}
+.list2 a:link {color:#000000; text-decoration:none}
+.list2 a:visited {color:#3e2f18; text-decoration:none}
+.list2 a:hover {color:#FFFFFF; text-decoration:underline}
+.list2 {padding-left:25px}
+/*.ne {margin-top:-70; float:right}*/
 
 
-div.footer {background-color:#D3AC92; clear:both; font-size:14px}
-div.footer h4 { text-align:right; padding-right:20px}
-div.footer a {text-decoration:none}
-div.footer a:link {color:#000000}
-div.footer a:visited {color:#000000}
-div.footer a:hover {color:#FFFFFF}
+
+
+.footer {background-color:#D3AC92; clear:both; font-size:14px}
+.footer h4 { text-align:right; padding-right:20px}
+.footer a {text-decoration:none}
+.footer a:link {color:#000000}
+.footer a:visited {color:#000000}
+.footer a:hover {color:#FFFFFF}
 
 p.bold {font-family:Arial, Helvetica, sans-serif; font-weight:bold; margin:10px 0px 10px 0px; font-size:13px}
-div.content a:link {color:#10669b}
-div.content a:visited {color:#00568b}
-div.content a:hover {color:#d2e8f6}
+.content a:link {color:#10669b}
+.content a:visited {color:#00568b}
+.content a:hover {color:#d2e8f6}

--- a/css/aow.css
+++ b/css/aow.css
@@ -99,18 +99,18 @@ a.sr-only.skip-link {
   background-color: white;
 }
 
-.green-banner {
+.static-banner {
   background-color: #bbdfbb;
-  border-bottom: 2px solid #466f46;
+  border-bottom: 1px solid #466f46;
   padding: 15px 20px;
 }
 
-.green-banner p {
+.static-banner p {
   margin: 0;
 }
 
-.green-banner p a,
-.green-banner p a:visited {
+.static-banner p a,
+.static-banner p a:visited {
   color: #0000EE;
   background: none;
   margin: 0;
@@ -118,7 +118,7 @@ a.sr-only.skip-link {
   text-decoration: underline;
 }
 
-.green-banner p a:hover {
+.static-banner p a:hover {
   background: none;
   color: #010194;
   margin: 0;

--- a/css/aow.css
+++ b/css/aow.css
@@ -7,7 +7,7 @@ body { color:#000000; font-family:"Times New Roman", Times, serif;  background:u
 
 .content {background:url(../web-images/lightblue.jpg) repeat}
 .content h1 {font-size:30px; padding: 15px 0px 0px 15px}
-.content h2 {font-family:Arial, Helvetica, sans-serif; font-style:italic; font-weight:bold; font-size:20px; padding: 15px 0px 10px 20px}
+.content h2, .content > h1:first-child {font-family:Arial, Helvetica, sans-serif; font-style:italic; font-weight:bold; font-size:20px; padding: 15px 0px 10px 20px}
 
 
 .content p {font-size:14px; line-height:1.5em; padding:8px 15px 8px 15px}
@@ -39,7 +39,7 @@ ul.mainmenu li li{padding:5px; padding-left:40px}
 
 .listlow {background:url(../web-images/darkblue2.jpg) repeat}
 .listlow li {padding:10px 0px 10px 50px; font-family:Arial, Helvetica, sans-serif; font-weight:bold; font-size:12px}
-.listlow h1 {font-size:14px; font-weight:bold; margin-left:-8px}
+.listlow h1, .listlow h2 {font-size:14px; font-weight:bold; margin-left:-8px}
 .listlow a:link {color:#000000; text-decoration:none}
 .listlow a:visited {color:#3e2f18; text-decoration:none}
 .listlow a:hover {color:#1D1202; text-decoration: underline 2px #1D1202;}
@@ -58,7 +58,7 @@ strong { font-weight: bold; }
 .footer a {text-decoration:none}
 .footer a:link {color:#000000}
 .footer a:visited {color:#000000}
-.footer a:hover {color:#FFFFFF}
+.footer a:hover {color:#1D1202; text-decoration: underline 2px #1D1202;}
 
 
 

--- a/css/aow.css
+++ b/css/aow.css
@@ -5,13 +5,13 @@ body { color:#000000; font-family:"Times New Roman", Times, serif;  background:u
 
 .header {background:url(../web-images/header2.jpg) top left; width:899px; height:88px}
 
-.content {background:url(../web-images/lightblue.jpg) repeat}
+.content {background:url(../web-images/lightblue.jpg) repeat; background-color: #cfe8ff;}
 .content h1 {font-size:30px; padding: 15px 0px 0px 15px}
 .content h2, .content > h1:first-child {font-family:Arial, Helvetica, sans-serif; font-style:italic; font-weight:bold; font-size:20px; padding: 15px 0px 10px 20px}
 
 
 .content p {font-size:14px; line-height:1.5em; padding:8px 15px 8px 15px}
-.content a:link {color:#2d6fa7}
+.content a:link {color:#10669b}
 .content a:visited {color:#004179}
 .content a:hover {color:#003454; text-decoration: underline #003454 2px;}
 .content blockquote {/*background-color:#FFFFFF;*/ font-family:Arial, Helvetica, sans-serif; font-style:italic; font-weight:bold}
@@ -39,7 +39,7 @@ ul.mainmenu li li{padding:5px; padding-left:40px}
 
 .listlow {background:url(../web-images/darkblue2.jpg) repeat}
 .listlow li {padding:10px 0px 10px 50px; font-family:Arial, Helvetica, sans-serif; font-weight:bold; font-size:12px}
-.listlow h1, .listlow h2 {font-size:14px; font-weight:bold; margin-left:-8px}
+.listlow h1, .listlow h2, .listlow span.h1 {font-size:14px; font-weight:bold; margin-left:-8px}
 .listlow a:link {color:#000000; text-decoration:none}
 .listlow a:visited {color:#3e2f18; text-decoration:none}
 .listlow a:hover {color:#1D1202; text-decoration: underline 2px #1D1202;}

--- a/css/aow.css
+++ b/css/aow.css
@@ -63,3 +63,37 @@ div.footer a:hover {color:#FFFFFF}
 
 
 .right {float: right}
+
+/* /////////////////
+Accessibility Fixes
+///////////////// */
+
+/* Skip to main content link */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.sr-only-focusable:active, .sr-only-focusable:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+}
+
+a.sr-only-focusable:hover, a.sr-only-focusable:focus {
+  color: #345c87;
+  text-decoration: underline;
+}
+
+a.sr-only.skip-link {
+  background-color: white;
+}

--- a/css/aow.css
+++ b/css/aow.css
@@ -54,12 +54,13 @@ strong { font-weight: bold; }
 
 
 /*.ne {margin-top:-70px; margin-left:70px}*/
-.footer {background-color:#D3AC92; font-size:14px; clear:both; text-align:right; padding-right:20px; height: 110px;}
+footer {background-color:#D3AC92; font-size:14px; clear:both; text-align:right; padding-right:20px; height: 110px;}
+.footer 
+{ width: auto;  min-width: 740px; max-width: 90em; padding-top: 5px; }
 .footer a {text-decoration:none}
 .footer a:link {color:#000000}
 .footer a:visited {color:#000000}
 .footer a:hover {color:#1D1202; text-decoration: underline 2px #1D1202;}
-
 
 
 .right {float: right}
@@ -96,4 +97,30 @@ a.sr-only-focusable:hover, a.sr-only-focusable:focus {
 
 a.sr-only.skip-link {
   background-color: white;
+}
+
+.green-banner {
+  background-color: #bbdfbb;
+  border-bottom: 2px solid #466f46;
+  padding: 15px 20px;
+}
+
+.green-banner p {
+  margin: 0;
+}
+
+.green-banner p a,
+.green-banner p a:visited {
+  color: #0000EE;
+  background: none;
+  margin: 0;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.green-banner p a:hover {
+  background: none;
+  color: #010194;
+  margin: 0;
+  padding: 0;
 }

--- a/css/aow.css
+++ b/css/aow.css
@@ -3,62 +3,62 @@
 
 body { color:#000000; font-family:"Times New Roman", Times, serif;  background:url(../web-images/darkblue2.jpg) repeat; background-color:#88C2E6 } 
 
-div.header {background:url(../web-images/header2.jpg) top left; width:899px; height:88px}
+.header {background:url(../web-images/header2.jpg) top left; width:899px; height:88px}
 
-div.content {background:url(../web-images/lightblue.jpg) repeat}
-div.content h1 {font-size:30px; padding: 15px 0px 0px 15px}
-div.content h2 {font-family:Arial, Helvetica, sans-serif; font-style:italic; font-weight:bold; font-size:20px; padding: 15px 0px 10px 20px}
+.content {background:url(../web-images/lightblue.jpg) repeat}
+.content h1 {font-size:30px; padding: 15px 0px 0px 15px}
+.content h2 {font-family:Arial, Helvetica, sans-serif; font-style:italic; font-weight:bold; font-size:20px; padding: 15px 0px 10px 20px}
 
 
-div.content p {font-size:14px; line-height:1.5em; padding:8px 15px 8px 15px}
-div.content a:link {color:#2d6fa7}
-div.content a:visited {color:#004179}
-div.content a:hover {color:#79aad3}
-div.content blockquote {/*background-color:#FFFFFF;*/ font-family:Arial, Helvetica, sans-serif; font-style:italic; font-weight:bold}
-div.content blockquote p {padding: 10px 35px 10px 35px; font-size: 12px; }
-div.content span.quoted {/*background-color:#FFFFFF;*/ display: block; font-family:Arial, Helvetica, sans-serif; font-style:italic; font-size:12px; font-weight:bold; padding: 10px 35px 10px 35px; margin: 10px; }
-div.fig {/*background-color:#FFFFFF;*/ font-style:italic; font-weight:bold; margin-top:15px}
-div.image {float:left; padding:10px; margin-top:-15px}
-div.fig p {margin-left:90px}
+.content p {font-size:14px; line-height:1.5em; padding:8px 15px 8px 15px}
+.content a:link {color:#2d6fa7}
+.content a:visited {color:#004179}
+.content a:hover {color:#79aad3}
+.content blockquote {/*background-color:#FFFFFF;*/ font-family:Arial, Helvetica, sans-serif; font-style:italic; font-weight:bold}
+.content blockquote p {padding: 10px 35px 10px 35px; font-size: 12px; }
+.content span.quoted {/*background-color:#FFFFFF;*/ display: block; font-family:Arial, Helvetica, sans-serif; font-style:italic; font-size:12px; font-weight:bold; padding: 10px 35px 10px 35px; margin: 10px; }
+.fig {/*background-color:#FFFFFF;*/ font-style:italic; font-weight:bold; margin-top:15px}
+.image {float:left; padding:10px; margin-top:-15px}
+.fig p {margin-left:90px}
 
 #main {background:url(../web-images/darkblue2.jpg) repeat}
 ul.mainmenu ul {font-size:12px; font-family:Arial, Helvetica, sans-serif; font-weight:bold; background-color:#acc4e2; padding-top:15px; padding-bottom:15px}
 ul.mainmenu li li{padding:5px; padding-left:40px}
-div.list {margin-top:20px}
-div.list a:link{color:#000000; text-decoration:none}
-div.list a:visited{color:#3e2f18; text-decoration:none}
-div.list a:hover{color:#FFFFFF; text-decoration:none}
-div.list h3 a:link {color:#660000}
-div.list h3 a:visited {color:#660000}
-div.list h3 a:hover {color:#FFFFFF}
-div.list li.selected h3{ background-color:#ed9459; margin-bottom:0px}
-div.list li.hidden ul {display:none}
-div.list ul.mainmenu li.current {background-color:#769fd2}
-div.list li {list-style-type:none }
-div.list h3 { margin-bottom:20px; font-weight:bold; padding-left:20px; color:#4D230F; background-color:#D3AC92}
+.list {margin-top:20px}
+.list a:link{color:#000000; text-decoration:none}
+.list a:visited{color:#3e2f18; text-decoration:none}
+.list a:hover{color:#FFFFFF; text-decoration:none}
+.list h3 a:link {color:#660000}
+.list h3 a:visited {color:#660000}
+.list h3 a:hover {color:#FFFFFF}
+.list li.selected h3{ background-color:#ed9459; margin-bottom:0px}
+.list li.hidden ul {display:none}
+.list ul.mainmenu li.current {background-color:#769fd2}
+.list li {list-style-type:none }
+.list h3 { margin-bottom:20px; font-weight:bold; padding-left:20px; color:#4D230F; background-color:#D3AC92}
 
-div.listlow {background:url(../web-images/darkblue2.jpg) repeat}
-div.listlow li {padding:10px 0px 10px 50px; font-family:Arial, Helvetica, sans-serif; font-weight:bold; font-size:12px}
-div.listlow h1 {font-size:14px; font-weight:bold; margin-left:-8px}
-div.listlow a:link {color:#000000; text-decoration:none}
-div.listlow a:visited {color:#3e2f18; text-decoration:none}
-div.listlow a:hover {color:#FFFFFF; text-decoration:underline}
+.listlow {background:url(../web-images/darkblue2.jpg) repeat}
+.listlow li {padding:10px 0px 10px 50px; font-family:Arial, Helvetica, sans-serif; font-weight:bold; font-size:12px}
+.listlow h1 {font-size:14px; font-weight:bold; margin-left:-8px}
+.listlow a:link {color:#000000; text-decoration:none}
+.listlow a:visited {color:#3e2f18; text-decoration:none}
+.listlow a:hover {color:#FFFFFF; text-decoration:underline}
 
 h3.listhead {font-size:14px; clear:left; font-weight:bold; padding-left:20px}
-div.content ul {clear:left; padding-bottom:20px}
-div.content li {padding-left:30px; font-size:12px; font-weight:normal}
+.content ul {clear:left; padding-bottom:20px}
+.content li {padding-left:30px; font-size:12px; font-weight:normal}
 
 ul.definitionList {list-style: square; margin: 0px; padding: 0px; margin-left: 10px; clear: none;}
 ul.definitionList li { font-size: .9em; padding-bottom: 10px; clear: none;}
 strong { font-weight: bold; }
 
 
-/*div.ne {margin-top:-70px; margin-left:70px}*/
-div.footer {background-color:#D3AC92; font-size:14px; clear:both; text-align:right; padding-right:20px; height: 110px;}
-div.footer a {text-decoration:none}
-div.footer a:link {color:#000000}
-div.footer a:visited {color:#000000}
-div.footer a:hover {color:#FFFFFF}
+/*.ne {margin-top:-70px; margin-left:70px}*/
+.footer {background-color:#D3AC92; font-size:14px; clear:both; text-align:right; padding-right:20px; height: 110px;}
+.footer a {text-decoration:none}
+.footer a:link {color:#000000}
+.footer a:visited {color:#000000}
+.footer a:hover {color:#FFFFFF}
 
 
 

--- a/css/aow.css
+++ b/css/aow.css
@@ -13,7 +13,7 @@ body { color:#000000; font-family:"Times New Roman", Times, serif;  background:u
 .content p {font-size:14px; line-height:1.5em; padding:8px 15px 8px 15px}
 .content a:link {color:#2d6fa7}
 .content a:visited {color:#004179}
-.content a:hover {color:#79aad3}
+.content a:hover {color:#003454; text-decoration: underline #003454 2px;}
 .content blockquote {/*background-color:#FFFFFF;*/ font-family:Arial, Helvetica, sans-serif; font-style:italic; font-weight:bold}
 .content blockquote p {padding: 10px 35px 10px 35px; font-size: 12px; }
 .content span.quoted {/*background-color:#FFFFFF;*/ display: block; font-family:Arial, Helvetica, sans-serif; font-style:italic; font-size:12px; font-weight:bold; padding: 10px 35px 10px 35px; margin: 10px; }
@@ -27,10 +27,10 @@ ul.mainmenu li li{padding:5px; padding-left:40px}
 .list {margin-top:20px}
 .list a:link{color:#000000; text-decoration:none}
 .list a:visited{color:#3e2f18; text-decoration:none}
-.list a:hover{color:#FFFFFF; text-decoration:none}
+.list a:hover{color:#1D1202; text-decoration: underline 2px #1D1202;}
 .list h3 a:link {color:#660000}
 .list h3 a:visited {color:#660000}
-.list h3 a:hover {color:#FFFFFF}
+.list h3 a:hover {color:#492B01; text-decoration: underline 2px #492B01;}
 .list li.selected h3{ background-color:#ed9459; margin-bottom:0px}
 .list li.hidden ul {display:none}
 .list ul.mainmenu li.current {background-color:#769fd2}
@@ -42,7 +42,7 @@ ul.mainmenu li li{padding:5px; padding-left:40px}
 .listlow h1 {font-size:14px; font-weight:bold; margin-left:-8px}
 .listlow a:link {color:#000000; text-decoration:none}
 .listlow a:visited {color:#3e2f18; text-decoration:none}
-.listlow a:hover {color:#FFFFFF; text-decoration:underline}
+.listlow a:hover {color:#1D1202; text-decoration: underline 2px #1D1202;}
 
 h3.listhead {font-size:14px; clear:left; font-weight:bold; padding-left:20px}
 .content ul {clear:left; padding-bottom:20px}

--- a/css/ie.css
+++ b/css/ie.css
@@ -1,6 +1,6 @@
 /* CSS Document */
 /* For IE cuz IE is dumb */
 
-div.body {color:#00FF00}
-div.footer {clear:none;}
-div.listlow {background:url(../web-images/darkblue2.jpg) repeat}
+.body {color:#00FF00}
+.footer {clear:none;}
+.listlow {background:url(../web-images/darkblue2.jpg) repeat}

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 <div class="header">
 <a class="sr-only sr-only-focusable skip-link" href="#main">Skip to main content</a>
 
-<h1>Army Officer's Wives on the Great Plains </h1>
+<span class="sr-only">Army Officer's Wives on the Great Plains </span>
 </div>
 </header>
   
@@ -38,7 +38,7 @@
 </div>
 
 <div class="title">
-<h1>
+<h1><span class="sr-only">Army Officer's Wives on the Great Plains </span>
 Introduction: The Girl I left Behind Me
 </h1>
 </div>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 <header class="blue">
   <div class="static-banner-wrapper">
     <div class="static-banner">
-      <p>This version of the website was created in 2025. See the <a href="#">Site Information Page</a> for contact information, data downloads, and other details.</p>
+      <p>This version of the website was created in 2025. See the <a href="info.html">Site Information Page</a> for contact information, data downloads, and other details.</p>
     </div>
   </div>
 <div class="header">

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 <header class="blue">
   <div class="static-banner-wrapper">
     <div class="static-banner">
-      <p>This is a simplified version of the website with no active updates. See the <a href="#">Site Information Page</a> for contact information, data downloads, and other details. </p>
+      <p>This version of the website was created in 2025. See the <a href="#">Site Information Page</a> for contact information, data downloads, and other details.</p>
     </div>
   </div>
 <div class="header">

--- a/index.html
+++ b/index.html
@@ -13,6 +13,11 @@
 <body>
 
 <header class="blue">
+  <div class="green-banner-wrapper">
+    <div class="green-banner">
+      <p>This is a simplified version of the website with no active updates. See the <a href="#">Site Information Page</a> for contact information, data downloads, and other details. </p>
+    </div>
+  </div>
 <div class="header">
 <a class="sr-only sr-only-focusable skip-link" href="#main">Skip to main content</a>
 

--- a/index.html
+++ b/index.html
@@ -13,8 +13,8 @@
 <body>
 
 <header class="blue">
-  <div class="green-banner-wrapper">
-    <div class="green-banner">
+  <div class="static-banner-wrapper">
+    <div class="static-banner">
       <p>This is a simplified version of the website with no active updates. See the <a href="#">Site Information Page</a> for contact information, data downloads, and other details. </p>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -12,14 +12,15 @@
 </head>
 <body>
 
-<div class="blue">
+<header class="blue">
 <div class="header">
+<a class="sr-only sr-only-focusable skip-link" href="#main">Skip to main content</a>
 
 <h1>Army Officer's Wives on the Great Plains </h1>
 </div>
-</div>
+</header>
   
-  <div id="page_margins">
+  <main id="page_margins">
 
     <div id="main">
       <div id="col1">
@@ -33,7 +34,7 @@
 <div class="content">
 
 <div class="photo">
-<h1> Main Photo </h1>
+	&nbsp;
 </div>
 
 <div class="title">
@@ -115,13 +116,10 @@ Introduction: The Girl I left Behind Me
       </div>
     </div>
     
-  </div>
-  <!--<div class="ne">
-  <img src="../../adam/army wives/vectors/ne.jpg"  />
-  </div>-->
-<div class="footer"><h4><a href="http://plainshumanities.unl.edu/army_officers_wives/about/methodology">Methodology</a> | 
+  </main>
+<footer class="footer"><p><a href="http://plainshumanities.unl.edu/army_officers_wives/about/methodology">Methodology</a> | 
 	<a href="http://plainshumanities.unl.edu/army_officers_wives/about/acknowledgements">Acknowledgements</a> | 
-	<a href="http://plainshumanities.unl.edu/army_officers_wives/about/barbara_handy-marchello">About the Author</a></h4><h4><a href="http://www.unl.edu">University of Nebraska-Lincoln</a>, <a href="http://cdrh.unl.edu">Center for Digital Research in the Humanities</a></h4><img src="http://plainshumanities.unl.edu/army_officers_wives/web-images/unl_logo.gif" class="right"/></div>
+	<a href="http://plainshumanities.unl.edu/army_officers_wives/about/barbara_handy-marchello">About the Author</a></p><p><a href="http://www.unl.edu">University of Nebraska-Lincoln</a>, <a href="http://cdrh.unl.edu">Center for Digital Research in the Humanities</a></p><img src="http://plainshumanities.unl.edu/army_officers_wives/web-images/unl_logo.gif" class="right" alt="" role="presentation"/></footer>
 
 </body>
 </html>

--- a/sitemap.xmap
+++ b/sitemap.xmap
@@ -175,7 +175,10 @@
         <map:read src="css/{1}.css" mime-type="text/css"/>
       </map:match>  
       
-      
+      <map:handle-errors>
+          <map:read src="404.html"/>
+          <map:serialize  type="html" status-code="404"/>
+        </map:handle-errors>
       
     </map:pipeline>
   </map:pipelines>

--- a/xsl/aow.formatting.xsl
+++ b/xsl/aow.formatting.xsl
@@ -67,7 +67,7 @@
   </xsl:template>
 
 	<xsl:template match="body/head">
-	<h2><xsl:apply-templates /></h2>
+	<h1><xsl:apply-templates /></h1>
 	</xsl:template>
 
 	<xsl:template match="quote">

--- a/xsl/aow.tei.xsl
+++ b/xsl/aow.tei.xsl
@@ -24,10 +24,18 @@
 
 </head>
 <body>
-	  	<header class="header">
-  <a class="sr-only sr-only-focusable skip-link" href="#main">Skip to main content</a>
+<header>
+        <a class="sr-only sr-only-focusable skip-link" href="#main">Skip to main content</a>
+        <div class="green-banner-wrapper">
+            <div class="green-banner">
+              <p>This is a simplified version of the website with no active updates. See the <a href="#">Site Information Page</a> for contact information, data downloads, and other details. </p>
+            </div>
+          </div>
+  	<div class="header">
+        
         <span class="sr-only">Army Officers' Wives on the Great Plains, 1865-1900</span>
-		</header>
+	</div>
+</header>
   <main id="page_margins">
 	  
 
@@ -72,14 +80,16 @@
   </main>
   	<!--<div class="ne"><img src="../web-images/ne.jpg" /></div>-->
 
-  <footer class="footer">
-  <p><!--<span class="fig"><span class="hidden"><span class="ne"></span></span></span>-->
-  	
-	<a href="{$BASE_HREF}about/methodology">Methodology</a> | 
-	<a href="{$BASE_HREF}about/acknowledgements">Acknowledgements</a> | 
-	<a href="{$BASE_HREF}about/barbara_handy-marchello">About the Author</a></p>
-  	<p><a href="http://www.unl.edu">University of Nebraska-Lincoln</a>, <a href="http://cdrh.unl.edu">Center for Digital Research in the Humanities</a> </p>
-  	<img src="{$BASE_HREF}web-images/unl_logo.gif" class="right" alt="" role="presentation"/> 
+  <footer>
+    <div class="footer">
+      <p><!--<span class="fig"><span class="hidden"><span class="ne"></span></span></span>-->
+      	
+    	<a href="{$BASE_HREF}about/methodology">Methodology</a> | 
+    	<a href="{$BASE_HREF}about/acknowledgements">Acknowledgements</a> | 
+    	<a href="{$BASE_HREF}about/barbara_handy-marchello">About the Author</a></p>
+      	<p><a href="http://www.unl.edu">University of Nebraska-Lincoln</a>, <a href="http://cdrh.unl.edu">Center for Digital Research in the Humanities</a> </p>
+      	<img src="{$BASE_HREF}web-images/unl_logo.gif" class="right" alt="" role="presentation"/> 
+    </div>
 </footer>
 
 </body>

--- a/xsl/aow.tei.xsl
+++ b/xsl/aow.tei.xsl
@@ -9,7 +9,7 @@
 
     
     <xsl:template match="/">
-        <html xmlns="http://www.w3.org/1999/xhtml">
+        <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" >
 <head>
 <title><xsl:value-of select="//title[@level='m' and @type='main']" /></title>
 <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
@@ -41,10 +41,10 @@
 	
 	<div class="listlow">
 	<ul class="lowermenu">
-		<li><h1>Context</h1></li>
+		<li><span class="h1">Context</span></li>
 		<li><a href="{$BASE_HREF}biographies">The Women</a></li>
 		<li><a href="{$BASE_HREF}military_posts">Military Posts</a></li>
-		<li><h1>About the Project</h1></li>
+		<li><span class="h1">About the Project</span></li>
 		<li><a href="{$BASE_HREF}bibliography">Bibliography</a></li>
 		<li><a href="{$BASE_HREF}lesson_plans">Lesson Plans</a></li>
 	</ul>
@@ -73,12 +73,12 @@
   	<!--<div class="ne"><img src="../web-images/ne.jpg" /></div>-->
 
   <footer class="footer">
-  <h4><!--<span class="fig"><span class="hidden"><span class="ne"></span></span></span>-->
+  <p><!--<span class="fig"><span class="hidden"><span class="ne"></span></span></span>-->
   	
 	<a href="{$BASE_HREF}about/methodology">Methodology</a> | 
 	<a href="{$BASE_HREF}about/acknowledgements">Acknowledgements</a> | 
-	<a href="{$BASE_HREF}about/barbara_handy-marchello">About the Author</a></h4>
-  	<h4><a href="http://www.unl.edu">University of Nebraska-Lincoln</a>, <a href="http://cdrh.unl.edu">Center for Digital Research in the Humanities</a> </h4>
+	<a href="{$BASE_HREF}about/barbara_handy-marchello">About the Author</a></p>
+  	<p><a href="http://www.unl.edu">University of Nebraska-Lincoln</a>, <a href="http://cdrh.unl.edu">Center for Digital Research in the Humanities</a> </p>
   	<img src="{$BASE_HREF}web-images/unl_logo.gif" class="right" alt="" role="presentation"/> 
 </footer>
 

--- a/xsl/aow.tei.xsl
+++ b/xsl/aow.tei.xsl
@@ -28,7 +28,7 @@
         <a class="sr-only sr-only-focusable skip-link" href="#main">Skip to main content</a>
         <div class="static-banner-wrapper">
             <div class="static-banner">
-              <p>This version of the website was created in 2025. See the <a href="#">Site Information Page</a> for contact information, data downloads, and other details.</p>
+              <p>This version of the website was created in 2025. See the <a href="info.html">Site Information Page</a> for contact information, data downloads, and other details.</p>
             </div>
           </div>
   	<div class="header">

--- a/xsl/aow.tei.xsl
+++ b/xsl/aow.tei.xsl
@@ -26,8 +26,8 @@
 <body>
 <header>
         <a class="sr-only sr-only-focusable skip-link" href="#main">Skip to main content</a>
-        <div class="green-banner-wrapper">
-            <div class="green-banner">
+        <div class="static-banner-wrapper">
+            <div class="static-banner">
               <p>This is a simplified version of the website with no active updates. See the <a href="#">Site Information Page</a> for contact information, data downloads, and other details. </p>
             </div>
           </div>

--- a/xsl/aow.tei.xsl
+++ b/xsl/aow.tei.xsl
@@ -24,12 +24,13 @@
 
 </head>
 <body>
+	  	<header class="header">
   <a class="sr-only sr-only-focusable skip-link" href="#main">Skip to main content</a>
-  <div id="page_margins">
+        <span class="sr-only">Army Officers' Wives on the Great Plains, 1865-1900</span>
+		</header>
+  <main id="page_margins">
 	  
-	  	<div class="header">
-		<a href="{$BASE_HREF}"><img src="../web-images/header2.jpg" alt="Officers' Row at Fort Robinson" /></a>
-		</div>
+
 
     <div id="main">
 
@@ -68,10 +69,10 @@
 
     </div>
 
-  </div>
+  </main>
   	<!--<div class="ne"><img src="../web-images/ne.jpg" /></div>-->
 
-  <div class="footer">
+  <footer class="footer">
   <h4><!--<span class="fig"><span class="hidden"><span class="ne"></span></span></span>-->
   	
 	<a href="{$BASE_HREF}about/methodology">Methodology</a> | 
@@ -79,7 +80,7 @@
 	<a href="{$BASE_HREF}about/barbara_handy-marchello">About the Author</a></h4>
   	<h4><a href="http://www.unl.edu">University of Nebraska-Lincoln</a>, <a href="http://cdrh.unl.edu">Center for Digital Research in the Humanities</a> </h4>
   	<img src="{$BASE_HREF}web-images/unl_logo.gif" class="right" /> 
-</div>
+</footer>
 
 </body>
 </html>

--- a/xsl/aow.tei.xsl
+++ b/xsl/aow.tei.xsl
@@ -24,11 +24,11 @@
 
 </head>
 <body>
-
+  <a class="sr-only sr-only-focusable skip-link" href="#main">Skip to main content</a>
   <div id="page_margins">
 	  
 	  	<div class="header">
-		<a href="{$BASE_HREF}"><img src="../web-images/header2.jpg" /></a>
+		<a href="{$BASE_HREF}"><img src="../web-images/header2.jpg" alt="Officers' Row at Fort Robinson" /></a>
 		</div>
 
     <div id="main">

--- a/xsl/aow.tei.xsl
+++ b/xsl/aow.tei.xsl
@@ -79,7 +79,7 @@
 	<a href="{$BASE_HREF}about/acknowledgements">Acknowledgements</a> | 
 	<a href="{$BASE_HREF}about/barbara_handy-marchello">About the Author</a></h4>
   	<h4><a href="http://www.unl.edu">University of Nebraska-Lincoln</a>, <a href="http://cdrh.unl.edu">Center for Digital Research in the Humanities</a> </h4>
-  	<img src="{$BASE_HREF}web-images/unl_logo.gif" class="right" /> 
+  	<img src="{$BASE_HREF}web-images/unl_logo.gif" class="right" alt="" role="presentation"/> 
 </footer>
 
 </body>

--- a/xsl/aow.tei.xsl
+++ b/xsl/aow.tei.xsl
@@ -28,7 +28,7 @@
         <a class="sr-only sr-only-focusable skip-link" href="#main">Skip to main content</a>
         <div class="static-banner-wrapper">
             <div class="static-banner">
-              <p>This is a simplified version of the website with no active updates. See the <a href="#">Site Information Page</a> for contact information, data downloads, and other details. </p>
+              <p>This version of the website was created in 2025. See the <a href="#">Site Information Page</a> for contact information, data downloads, and other details.</p>
             </div>
           </div>
   	<div class="header">


### PR DESCRIPTION
A11y fixes for 
* Skip to Main Content link
* Page regions (`main`, `header`, `footer`)
* Headings (site title = span, pages begin with h1
* Color contrast ratios

Does not address missing image alt tags in TEI figures; no alt text is available and would need to be adapted from long `fidDesc`s.

(Production site, on server cors1601, is currently on this branch)